### PR TITLE
Fix loading extended fields if nothing is specified

### DIFF
--- a/fields/radicalmultifield.php
+++ b/fields/radicalmultifield.php
@@ -83,7 +83,7 @@ class JFormFieldRadicalmultifield extends JFormFieldSubform
         //подзагружаем кастомные поля
 	    JLoader::import('radicalmultifieldhelper', JPATH_ROOT . '/plugins/fields/radicalmultifield');
 
-	    if(isset($params['extendfield']))
+	    if(isset($params['extendfield']) && !empty($params['extendfield']))
 	    {
 
 		    $extendField = explode("\n", $params['extendfield']);


### PR DESCRIPTION
Обнаружил неприятный баг
Если в плагине не задать ни одного "дополнительного поля", то плагин пытается загрузить все php файлы из корня сайта, пытаясь найти в них классы полей. Это приводит к самым непредсказуемым последствиям.
Добавил проверку на пустоту параметра, перед загрузкой классов.