### PR TITLE
Для Joomla 5.1 - Добавлен контекст com_finder.article

### DIFF
--- a/src/Extension/RadicalMultiField.php
+++ b/src/Extension/RadicalMultiField.php
@@ -197,6 +197,7 @@ class RadicalMultiField extends FieldsPlugin
 
 		$template_item = [
 			'com_content.article',
+			'com_finder.article',
 			'com_users.user',
 			'com_contact.contact',
 		];


### PR DESCRIPTION
Иначе сыпется индексация контента. В процессе индексации дёргаются плагины полей со специфичным контекстом `com_finder.article` и т.д. Плагин не отдавал параметр `$layout` для PLuginHelper. Туда приходило `null` , так как контекста умного поиска нет в RMF. Вылетало сообщение deprecated в json ответ даже при задавленных ошибках.
Схожим образом падала индексация через CLI. 