### PR TITLE
Refactor background-size properties in cards.css

### DIFF
--- a/media/css/cards.css
+++ b/media/css/cards.css
@@ -42,10 +42,10 @@
     align-items: center;
     align-self: center;
     transition: all 0.2s;
-    -webkit-background-size: contain !important;
-    -moz-background-size: contain !important;
-    -o-background-size: contain !important;
-    background-size: contain !important;
+    -webkit-background-size: contain;
+    -moz-background-size: contain;
+    -o-background-size: contain;
+    background-size: contain;
     background-position: 50% 50% !important;
     background-repeat: no-repeat;
     border: 1px solid rgba(50, 50, 50, 0.11);


### PR DESCRIPTION
Removed '!important' from background-size properties - messes up with admin template, can't override with user.css

Портит отображание превьюшек в админке, конфликтов правил нет, !important не требуется